### PR TITLE
fix: prevent infinite onClose call

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,7 +49,7 @@ const OauthPopup: React.FC<IPopupProps> = ({
   };
 
   useEffect(() => {
-    if (!externalWindow?.closed) {
+    if (externalWindow) {
       intervalRef.current = window.setInterval(() => {
         try {
           const currentUrl = externalWindow.location.href;
@@ -74,7 +74,7 @@ const OauthPopup: React.FC<IPopupProps> = ({
       if (externalWindow) externalWindow.close();
       if (onClose) onClose();
     };
-  });
+  },[externalWindow]);
 
   return (
     // eslint-disable-next-line

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -74,7 +74,7 @@ const OauthPopup: React.FC<IPopupProps> = ({
       if (externalWindow) externalWindow.close();
       if (onClose) onClose();
     };
-  },[externalWindow]);
+  }, [externalWindow]);
 
   return (
     // eslint-disable-next-line

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,7 +49,7 @@ const OauthPopup: React.FC<IPopupProps> = ({
   };
 
   useEffect(() => {
-    if (!externalWindow.closed) {
+    if (!externalWindow?.closed) {
       intervalRef.current = window.setInterval(() => {
         try {
           const currentUrl = externalWindow.location.href;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,7 +49,7 @@ const OauthPopup: React.FC<IPopupProps> = ({
   };
 
   useEffect(() => {
-    if (externalWindow) {
+    if (!externalWindow.closed) {
       intervalRef.current = window.setInterval(() => {
         try {
           const currentUrl = externalWindow.location.href;
@@ -74,7 +74,7 @@ const OauthPopup: React.FC<IPopupProps> = ({
       if (externalWindow) externalWindow.close();
       if (onClose) onClose();
     };
-  });
+  },[]);
 
   return (
     // eslint-disable-next-line

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -74,7 +74,7 @@ const OauthPopup: React.FC<IPopupProps> = ({
       if (externalWindow) externalWindow.close();
       if (onClose) onClose();
     };
-  }, []);
+  });
 
   return (
     // eslint-disable-next-line

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -74,7 +74,7 @@ const OauthPopup: React.FC<IPopupProps> = ({
       if (externalWindow) externalWindow.close();
       if (onClose) onClose();
     };
-  },[]);
+  }, []);
 
   return (
     // eslint-disable-next-line


### PR DESCRIPTION
Fixes https://github.com/kgoedecke/react-oauth-popup/issues/31

to reproduce (react 17)

perform an login and leave the component in place, do not redirect

print in onClose function and see that constantly being called because of the `finally` in the promise. 
that made me think if the timeouts are well placed and always valid in the vars that are generated.

possibly a memory leak further down the line? 


the suggested fix, has a check if the window is open , within the useEffect, and also an empty array of dependencies (in case this was meant to run only on first load, otherwise we can remove the latter)